### PR TITLE
Code rebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ events.json
 events.json.old
 events.ics
 events.ics.old
+*.ics
+*.bck

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ events.ics
 events.ics.old
 *.ics
 *.bck
+.pre-commit-config.yaml

--- a/hackeropuit.css
+++ b/hackeropuit.css
@@ -1,13 +1,15 @@
 @font-face {
-  font-family: 'OCR A Std';
+  font-family: "OCR A Std";
   font-style: normal;
   font-weight: normal;
-  src: local('OCR A Std'), url('OCRAStd.woff') format('woff');
+  src:
+    local("OCR A Std"),
+    url("OCRAStd.woff") format("woff");
 }
 
 body {
   background-color: black;
-  font-family: 'Open Sans', Sans-Serif;
+  font-family: "Open Sans", Sans-Serif;
   color: white;
   padding: 0px 5px;
 }
@@ -18,23 +20,27 @@ body {
   min-width: 1000px;
   padding: 25px 0px 20px 0px;
   text-align: center;
-  font: 128px 'OCR A Std';
-  text-shadow: 5px  5px 10px #000, -5px  5px 10px #000, 5px -5px 10px #000, -5px -5px 10px #000; 
-  background-image: url('computer-2930704_1280_half.jpg');
+  font: 128px "OCR A Std";
+  text-shadow:
+    5px 5px 10px #000,
+    -5px 5px 10px #000,
+    5px -5px 10px #000,
+    -5px -5px 10px #000;
+  background-image: url("computer-2930704_1280_half.jpg");
   background-position: bottom;
   background-size: cover;
 }
 
 a {
-  color: #8CF;
+  color: #8cf;
 }
 
 a:visited {
-  color: #8D5;
+  color: #8d5;
 }
 
 a:hover {
-  color: #8D5;
+  color: #8d5;
 }
 
 #infobar {
@@ -64,7 +70,7 @@ table {
 }
 
 thead {
-  background: #8CF;
+  background: #8cf;
   color: #000;
   font-weight: bold;
 }

--- a/hackeropuit.css
+++ b/hackeropuit.css
@@ -1,0 +1,88 @@
+@font-face {
+  font-family: 'OCR A Std';
+  font-style: normal;
+  font-weight: normal;
+  src: local('OCR A Std'), url('OCRAStd.woff') format('woff');
+}
+
+body {
+  background-color: black;
+  font-family: 'Open Sans', Sans-Serif;
+  color: white;
+  padding: 0px 5px;
+}
+
+#page-header {
+  width: 100%;
+  margin: 0px;
+  min-width: 1000px;
+  padding: 25px 0px 20px 0px;
+  text-align: center;
+  font: 128px 'OCR A Std';
+  text-shadow: 5px  5px 10px #000, -5px  5px 10px #000, 5px -5px 10px #000, -5px -5px 10px #000; 
+  background-image: url('computer-2930704_1280_half.jpg');
+  background-position: bottom;
+  background-size: cover;
+}
+
+a {
+  color: #8CF;
+}
+
+a:visited {
+  color: #8D5;
+}
+
+a:hover {
+  color: #8D5;
+}
+
+#infobar {
+  margin: 10px 0px;
+  display: flex;
+  justify-content: space-between;
+}
+
+#info-left {
+  display: flex;
+  gap: 10px;
+}
+
+#info-mid {
+  display: flex;
+  gap: 10px;
+}
+
+#info-right {
+  display: flex;
+  gap: 10px;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+thead {
+  background: #8CF;
+  color: #000;
+  font-weight: bold;
+}
+
+th {
+  cursor: pointer;
+  text-align: left;
+  padding: 0.9em 0.3em;
+}
+
+tr.even {
+  background: #222;
+}
+
+td {
+  padding: 0.4em 0.3em;
+}
+
+.hidden-col {
+  display: none;
+}

--- a/hackeropuit.js
+++ b/hackeropuit.js
@@ -6,7 +6,7 @@ function sortTable(colIndex) {
   const rows = Array.from(tbody.rows);
   const ths = table.querySelectorAll("th");
 
-  ths.forEach(th => th.classList.remove("sorted-asc", "sorted-desc"));
+  ths.forEach((th) => th.classList.remove("sorted-asc", "sorted-desc"));
   sortDirection[colIndex] = !sortDirection[colIndex];
 
   rows.sort((a, b) => {
@@ -14,8 +14,12 @@ function sortTable(colIndex) {
     const bText = b.cells[colIndex].textContent.trim().toLowerCase();
     const isDate = !isNaN(Date.parse(aText)) && !isNaN(Date.parse(bText));
     return sortDirection[colIndex]
-      ? isDate ? new Date(aText) - new Date(bText) : aText.localeCompare(bText)
-      : isDate ? new Date(bText) - new Date(aText) : bText.localeCompare(aText);
+      ? isDate
+        ? new Date(aText) - new Date(bText)
+        : aText.localeCompare(bText)
+      : isDate
+        ? new Date(bText) - new Date(aText)
+        : bText.localeCompare(aText);
   });
 
   rows.forEach((row, index) => {
@@ -24,7 +28,9 @@ function sortTable(colIndex) {
     tbody.appendChild(row);
   });
 
-  ths[colIndex].classList.add(sortDirection[colIndex] ? "sorted-asc" : "sorted-desc");
+  ths[colIndex].classList.add(
+    sortDirection[colIndex] ? "sorted-asc" : "sorted-desc",
+  );
 }
 
 function filterTable() {
@@ -44,8 +50,8 @@ function filterTable() {
 
       if (filter && lowerText.includes(filter)) {
         match = true;
-        const regex = new RegExp(`(${filter})`, 'gi');
-        cell.innerHTML = plainText.replace(regex, '<mark>$1</mark>');
+        const regex = new RegExp(`(${filter})`, "gi");
+        cell.innerHTML = plainText.replace(regex, "<mark>$1</mark>");
       } else {
         cell.innerHTML = plainText;
       }
@@ -65,30 +71,34 @@ function filterTable() {
 
 function exportTableToCSV() {
   const table = document.getElementById("eventtable");
-  const rows = Array.from(table.querySelectorAll("tbody tr")).filter(row => row.style.display !== "none");
+  const rows = Array.from(table.querySelectorAll("tbody tr")).filter(
+    (row) => row.style.display !== "none",
+  );
   let csv = [];
 
   // Get all <th> elements and determine which indexes to include (not marked with 'noexport')
   const thElements = Array.from(table.querySelectorAll("thead th"));
   const includedIndexes = thElements
-    .map((th, index) => th.classList.contains("noexport") ? null : index)
-    .filter(index => index !== null);
+    .map((th, index) => (th.classList.contains("noexport") ? null : index))
+    .filter((index) => index !== null);
 
   // Build the header row, excluding 'exclude' columns
-  const headers = includedIndexes.map(index => thElements[index].textContent.trim());
+  const headers = includedIndexes.map((index) =>
+    thElements[index].textContent.trim(),
+  );
   csv.push(headers.join(","));
 
   // Process each row
   for (let row of rows) {
     const cells = Array.from(row.cells);
-    const filteredCells = includedIndexes.map(index => {
+    const filteredCells = includedIndexes.map((index) => {
       const cell = cells[index];
       const link = cell.querySelector("a");
       const content = link ? link.href : cell.textContent;
       const cleaned = content
-		    .replace(/[\r\n]+/g, ' ')
-		    .trim()
-		    .replace(/"/g, '""');
+        .replace(/[\r\n]+/g, " ")
+        .trim()
+        .replace(/"/g, '""');
       return cleaned;
     });
     csv.push(filteredCells.join(","));
@@ -110,31 +120,50 @@ function exportToICalendar() {
 
   // Look for position of required data in the eventtable
   const headerCells = Array.from(table.querySelectorAll("thead th"));
-  const summaryIndex     = headerCells.findIndex(th => th.textContent.trim() === "Name");
-  const locationIndex    = headerCells.findIndex(th => th.textContent.trim() === "Location");
-  const descriptionIndex = headerCells.findIndex(th => th.textContent.trim() === "Comment");
-  const urlIndex         = headerCells.findIndex(th => th.textContent.trim() === "Website");
-  const dtStartIndex     = headerCells.findIndex(th => th.textContent.trim() === "StartDate");
-  const dtEndIndex       = headerCells.findIndex(th => th.textContent.trim() === "EndDate");
+  const summaryIndex = headerCells.findIndex(
+    (th) => th.textContent.trim() === "Name",
+  );
+  const locationIndex = headerCells.findIndex(
+    (th) => th.textContent.trim() === "Location",
+  );
+  const descriptionIndex = headerCells.findIndex(
+    (th) => th.textContent.trim() === "Comment",
+  );
+  const urlIndex = headerCells.findIndex(
+    (th) => th.textContent.trim() === "Website",
+  );
+  const dtStartIndex = headerCells.findIndex(
+    (th) => th.textContent.trim() === "StartDate",
+  );
+  const dtEndIndex = headerCells.findIndex(
+    (th) => th.textContent.trim() === "EndDate",
+  );
 
   let icsContent = "";
 
   // Select all (filtered) rows
-  const rows = Array.from(table.querySelectorAll("tbody tr")).filter(row => row.style.display !== "none");
+  const rows = Array.from(table.querySelectorAll("tbody tr")).filter(
+    (row) => row.style.display !== "none",
+  );
 
   for (const row of rows) {
     const cells = row.cells;
 
-    const uid         = escapeICalText(cells[summaryIndex].textContent.trim()+cells[dtStartIndex].textContent.trim())
-    const summary     = escapeICalText(cells[summaryIndex].textContent.trim());
-    const location    = escapeICalText(cells[locationIndex].textContent.trim());
-    const description = escapeICalText(cells[descriptionIndex].textContent.trim());
-    const link        = escapeICalText(cells[urlIndex].querySelector("a")?.href || "");
-    const start       = formatICalDate(cells[dtStartIndex].textContent.trim());
-    const end         = formatICalDate(cells[dtEndIndex].textContent.trim());
-    const stamp       = now.toISOString();
+    const uid = escapeICalText(
+      cells[summaryIndex].textContent.trim() +
+        cells[dtStartIndex].textContent.trim(),
+    );
+    const summary = escapeICalText(cells[summaryIndex].textContent.trim());
+    const location = escapeICalText(cells[locationIndex].textContent.trim());
+    const description = escapeICalText(
+      cells[descriptionIndex].textContent.trim(),
+    );
+    const link = escapeICalText(cells[urlIndex].querySelector("a")?.href || "");
+    const start = formatICalDate(cells[dtStartIndex].textContent.trim());
+    const end = formatICalDate(cells[dtEndIndex].textContent.trim());
+    const stamp = now.toISOString();
 
-    icsContent += 'BEGIN:VEVENT\n';
+    icsContent += "BEGIN:VEVENT\n";
     icsContent += `UID:${uid}\n`;
     icsContent += `SUMMARY:${summary}\n`;
     icsContent += `LOCATION:${location}\n`;
@@ -143,14 +172,15 @@ function exportToICalendar() {
     icsContent += `DTSTART;VALUE=DATE:${start}\n`;
     icsContent += `DTEND;VALUE=DATE:${end}\n`;
     icsContent += `DTSTAMP;VALUE=DATE:${stamp}\n`;
-    icsContent += 'END:VEVENT\n';
+    icsContent += "END:VEVENT\n";
   }
 
-  icsContent = "BEGIN:VCALENDAR\n"
-	+ "VERSION:2.0\n"
-	+ "PRODID:-//Hack er op uit//hackeropuit.nl\n"
-	+ icsContent
-  	+ "END:VCALENDAR";
+  icsContent =
+    "BEGIN:VCALENDAR\n" +
+    "VERSION:2.0\n" +
+    "PRODID:-//Hack er op uit//hackeropuit.nl\n" +
+    icsContent +
+    "END:VCALENDAR";
 
   const blob = new Blob([icsContent], { type: "text/calendar" });
   const link = document.createElement("a");
@@ -162,14 +192,15 @@ function exportToICalendar() {
 function formatICalDate(dateStr) {
   const date = new Date(dateStr);
   const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
   return `${year}${month}${day}`;
 }
 
 function escapeICalText(text) {
-  return text.replace(/\\n/g, "\\n")
-             .replace(/,/g, "\\,")
-             .replace(/;/g, "\\;")
-             .replace(/\r?\n/g, "\\n");
+  return text
+    .replace(/\\n/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;")
+    .replace(/\r?\n/g, "\\n");
 }

--- a/hackeropuit.js
+++ b/hackeropuit.js
@@ -1,0 +1,175 @@
+let sortDirection = {};
+
+function sortTable(colIndex) {
+  const table = document.getElementById("eventtable");
+  const tbody = table.tBodies[0];
+  const rows = Array.from(tbody.rows);
+  const ths = table.querySelectorAll("th");
+
+  ths.forEach(th => th.classList.remove("sorted-asc", "sorted-desc"));
+  sortDirection[colIndex] = !sortDirection[colIndex];
+
+  rows.sort((a, b) => {
+    const aText = a.cells[colIndex].textContent.trim().toLowerCase();
+    const bText = b.cells[colIndex].textContent.trim().toLowerCase();
+    const isDate = !isNaN(Date.parse(aText)) && !isNaN(Date.parse(bText));
+    return sortDirection[colIndex]
+      ? isDate ? new Date(aText) - new Date(bText) : aText.localeCompare(bText)
+      : isDate ? new Date(bText) - new Date(aText) : bText.localeCompare(aText);
+  });
+
+  rows.forEach((row, index) => {
+    row.classList.remove("odd", "even");
+    row.classList.add(index % 2 === 0 ? "even" : "odd");
+    tbody.appendChild(row);
+  });
+
+  ths[colIndex].classList.add(sortDirection[colIndex] ? "sorted-asc" : "sorted-desc");
+}
+
+function filterTable() {
+  const input = document.getElementById("searchInput");
+  const filter = input.value.toLowerCase();
+  const table = document.getElementById("eventtable");
+  const rows = table.tBodies[0].rows;
+
+  let visibleRowIndex = 0;
+
+  for (let row of rows) {
+    let match = false;
+
+    for (let cell of row.cells) {
+      const plainText = cell.textContent;
+      const lowerText = plainText.toLowerCase();
+
+      if (filter && lowerText.includes(filter)) {
+        match = true;
+        const regex = new RegExp(`(${filter})`, 'gi');
+        cell.innerHTML = plainText.replace(regex, '<mark>$1</mark>');
+      } else {
+        cell.innerHTML = plainText;
+      }
+    }
+
+    if (match || !filter) {
+      row.style.display = "";
+      row.classList.remove("odd", "even");
+      row.classList.add(visibleRowIndex % 2 === 0 ? "even" : "odd");
+      visibleRowIndex++;
+    } else {
+      row.style.display = "none";
+      row.classList.remove("odd", "even");
+    }
+  }
+}
+
+function exportTableToCSV() {
+  const table = document.getElementById("eventtable");
+  const rows = Array.from(table.querySelectorAll("tbody tr")).filter(row => row.style.display !== "none");
+  let csv = [];
+
+  // Get all <th> elements and determine which indexes to include (not marked with 'noexport')
+  const thElements = Array.from(table.querySelectorAll("thead th"));
+  const includedIndexes = thElements
+    .map((th, index) => th.classList.contains("noexport") ? null : index)
+    .filter(index => index !== null);
+
+  // Build the header row, excluding 'exclude' columns
+  const headers = includedIndexes.map(index => thElements[index].textContent.trim());
+  csv.push(headers.join(","));
+
+  // Process each row
+  for (let row of rows) {
+    const cells = Array.from(row.cells);
+    const filteredCells = includedIndexes.map(index => {
+      const cell = cells[index];
+      const link = cell.querySelector("a");
+      const content = link ? link.href : cell.textContent;
+      const cleaned = content
+		    .replace(/[\r\n]+/g, ' ')
+		    .trim()
+		    .replace(/"/g, '""');
+      return cleaned;
+    });
+    csv.push(filteredCells.join(","));
+  }
+
+  const csvString = csv.join("\n");
+  const blob = new Blob([csvString], { type: "text/csv" });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = "events.csv";
+  link.click();
+}
+
+function exportToICalendar() {
+  const now = new Date();
+
+  // Find eventtable with data first
+  const table = document.getElementById("eventtable");
+
+  // Look for position of required data in the eventtable
+  const headerCells = Array.from(table.querySelectorAll("thead th"));
+  const summaryIndex     = headerCells.findIndex(th => th.textContent.trim() === "Name");
+  const locationIndex    = headerCells.findIndex(th => th.textContent.trim() === "Location");
+  const descriptionIndex = headerCells.findIndex(th => th.textContent.trim() === "Comment");
+  const urlIndex         = headerCells.findIndex(th => th.textContent.trim() === "Website");
+  const dtStartIndex     = headerCells.findIndex(th => th.textContent.trim() === "StartDate");
+  const dtEndIndex       = headerCells.findIndex(th => th.textContent.trim() === "EndDate");
+
+  let icsContent = "";
+
+  // Select all (filtered) rows
+  const rows = Array.from(table.querySelectorAll("tbody tr")).filter(row => row.style.display !== "none");
+
+  for (const row of rows) {
+    const cells = row.cells;
+
+    const uid         = escapeICalText(cells[summaryIndex].textContent.trim()+cells[dtStartIndex].textContent.trim())
+    const summary     = escapeICalText(cells[summaryIndex].textContent.trim());
+    const location    = escapeICalText(cells[locationIndex].textContent.trim());
+    const description = escapeICalText(cells[descriptionIndex].textContent.trim());
+    const link        = escapeICalText(cells[urlIndex].querySelector("a")?.href || "");
+    const start       = formatICalDate(cells[dtStartIndex].textContent.trim());
+    const end         = formatICalDate(cells[dtEndIndex].textContent.trim());
+    const stamp       = now.toISOString();
+
+    icsContent += 'BEGIN:VEVENT\n';
+    icsContent += `UID:${uid}\n`;
+    icsContent += `SUMMARY:${summary}\n`;
+    icsContent += `LOCATION:${location}\n`;
+    icsContent += `DESCRIPTION:${description}\n`;
+    icsContent += `URL:${link}\n`;
+    icsContent += `DTSTART;VALUE=DATE:${start}\n`;
+    icsContent += `DTEND;VALUE=DATE:${end}\n`;
+    icsContent += `DTSTAMP;VALUE=DATE:${stamp}\n`;
+    icsContent += 'END:VEVENT\n';
+  }
+
+  icsContent = "BEGIN:VCALENDAR\n"
+	+ "VERSION:2.0\n"
+	+ "PRODID:-//Hack er op uit//hackeropuit.nl\n"
+	+ icsContent
+  	+ "END:VCALENDAR";
+
+  const blob = new Blob([icsContent], { type: "text/calendar" });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = "events.ics";
+  link.click();
+}
+
+function formatICalDate(dateStr) {
+  const date = new Date(dateStr);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+function escapeICalText(text) {
+  return text.replace(/\\n/g, "\\n")
+             .replace(/,/g, "\\,")
+             .replace(/;/g, "\\;")
+             .replace(/\r?\n/g, "\\n");
+}

--- a/index.tpl
+++ b/index.tpl
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <title>HackErOpUit</title>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="title" property="og:title" content="HackErOpUit" />
+    <meta name="keywords" content="hackeropuit, hackoutandabout, workshops, festivities, events, creative, inspirational, fun" />
+    <meta name="category" content="Hackerevents" />
+    <meta name="description" content="Catalog of upcoming events and workshops for makers, hackers, and other creative minds." />
+    <meta name="subject" content="Catalog of upcoming events and workshops for makers, hackers, and other creative minds." />
+    <meta name="summary" content="Catalog of upcoming events and workshops for makers, hackers, and other creative minds." />
+    <meta name="abstract" content="Catalog of upcoming events and workshops for makers, hackers, and other creative minds." />
+    <meta name="revised" content="{{NOW}}" />
+    <meta name="url" content="https://hackeropuit.nl" />
+    <meta name="identifier-url" content="https://hackeropuit.nl" />
+    <meta property="og:image" content="https://hackeropuit.nl/images/hackeropuit_logo_436_2.png" />
+    <meta property="og:image:type" content="image/png" />
+    <meta property="og:image:width" content="436" />
+    <meta property="og:image:height" content="228" />
+    <meta property="og:description" content="Catalog of upcoming events and workshops for makers, hackers, and other creative minds." />
+    <meta property="og:updated_time" content="{{NOW}}" />
+    <meta property="article:published_time" content="{{NOW}}" />
+    <meta property="article:authors" content="{{AUTHORS}}" />
+    <meta name="generator" content="HackerErOpUit" />
+    <meta name="generator_version" content="{{GENERATOR_VERSION}}" />
+    <meta name="generator_revision" content="{{GENERATOR_REVISION}}" />
+    <meta name="generator_author" content="sigio,foobar,elborro">
+    <meta name="robots" content="noindex" />
+    <meta name='revisit-after' content='7 days'>
+    <meta name="googlebot" content="notranslate" />
+    <meta name="googlebot-news" content="nosnippet" /> 
+    <link rel="canonical" href="https://hackeropuit.nl" />
+    <link rel="stylesheet" href="hackeropuit.css" />
+    <link rel="icon" type="image/x-icon" sizes="16x16" href="/images/ico/favicon.ico" />
+    <link rel="icon" type="image/png" sizes="640x640" href="/images/ico/favicon.png" />
+    <link rel="apple-touch-icon" sizes="640x640" href="/images/ico/favicon.png" />
+  </head>
+
+  <body>
+    <h1 id="page-header">HackErOpUit</h1>
+
+    <div id="infobar">
+      <div id="info-left">
+        <input type="text" id="searchInput" placeholder="Search table..." onkeyup="filterTable()" />
+        <button onclick="exportTableToCSV()">Export CSV</button>
+        <button onclick="exportToICalendar()">Export iCalendar</button>
+      </div>
+      <div id="info-mid">
+        <span>
+          Evenement of uitje toevoegen?
+          <a href="https://github.com/revspace/hackeropuit">Pull request!</a>
+        </span>
+      </div>
+      <div id="info-right">
+        <span id="icalfile"><a href="ical/all_events.ics">📅 [AllEvents.ics]</a></span>
+        <span id="lastUpdated">Last edit: {{LASTEDIT}}</span>
+        <span id="lastRefresh">Last refresh: {{LASTREFRESH}}</span>
+      </div>
+    </div>
+
+    <div id="events" />
+
+    <script src="hackeropuit.js" />
+  </body>
+</html>

--- a/update-website.py
+++ b/update-website.py
@@ -12,10 +12,14 @@ import re
 
 # Configuration
 OUTPUTFILE = 'new_index.html'
-EVENTDIR   = 'events'
-ICALDIR    = 'ical'
-VERSION    = '1.0'
-AUTHORS    = 'sigio,ubuntu-demon,kominoshja,tjclement,dekkers,JolienF,dutchmartin,amarsman,brainsmoke,eloydegen,juerd,stappersg,xesxen,mischapeters,polyfloyd,zeno4ever,toshywoshy,boekenwuurm,dvanzuilekom,elborro'
+EVENTDIR = 'events'
+ICALDIR = 'ical'
+VERSION = '1.0'
+AUTHORS = ("sigio,ubuntu-demon,kominoshja,tjclement,dekkers,JolienF,"
+           "dutchmartin,amarsman,brainsmoke,eloydegen,juerd,stappersg,"
+           "xesxen,mischapeters,polyfloyd,zeno4ever,toshywoshy,boekenwuurm,"
+           "dvanzuilekom,elborro"
+           )
 
 # Store current time to use the same timestamp in all generated files
 now = datetime.now(timezone.utc)
@@ -29,7 +33,7 @@ for filename in glob.glob("events/*.yaml"):
         with open(filename, "r", encoding="utf-8") as eventfile:
             eventdata = yaml.load(eventfile)
 
-            events=[]
+            events = []
             if isinstance(eventdata, list):
                 events.extend(eventdata)
             elif isinstance(eventdata, dict):
@@ -53,7 +57,12 @@ all_events = sorted(all_events, key=itemgetter('StartDate'))
 
 # Filter already passed events
 today = date.today()
-upcoming_events = [event for event in all_events if event['StartDate'] <= event['EndDate'] and today <= event['EndDate']]
+upcoming_events = [
+                    event
+                    for event in all_events
+                    if event['StartDate'] <= event['EndDate']
+                    and today <= event['EndDate']
+                   ]
 
 
 # Clean up iCalender folder
@@ -69,17 +78,17 @@ cal = Calendar()
 cal.add('prodid', '-//Hack er op uit//hackeropuit.nl//')
 cal.add('version', '2.0')
 
-for source_event in all_events:
+for evt in all_events:
     event = Event()
     event.add('dtstamp', now)
-    event.add('uid', f"/{source_event['Name']}/{source_event['StartDate']}")
-    event.add('summary', source_event['Name'])
+    event.add('uid', f"/{evt['Name']}/{evt['StartDate']}")
+    event.add('summary', evt['Name'])
     event.add('transp', 'TRANSPARENT')
-    event.add('dtstart', source_event['StartDate'])
-    event.add('dtend', source_event['EndDate'] + timedelta(days=1))
-    event.add('location', source_event['Location'])
-    event.add('description', source_event['Comment'])
-    event.add('url', source_event['URL'])
+    event.add('dtstart', evt['StartDate'])
+    event.add('dtend', evt['EndDate'] + timedelta(days=1))
+    event.add('location', evt['Location'])
+    event.add('description', evt['Comment'])
+    event.add('url', evt['URL'])
     cal.add_component(event)
 
 with open('ical/all_events.ics', 'wb') as f:
@@ -95,17 +104,17 @@ for file in files:
     cal.add('prodid', '-//Hack er op uit//hackeropuit.nl//')
     cal.add('version', '2.0')
 
-    for source_event in source_events:
+    for evt in source_events:
         event = Event()
         event.add('dtstamp', now)
-        event.add('uid', f"/{source_event['Name']}/{source_event['StartDate']}")
-        event.add('summary', source_event['Name'])
+        event.add('uid', f"/{evt['Name']}/{evt['StartDate']}")
+        event.add('summary', evt['Name'])
         event.add('transp', 'TRANSPARENT')
-        event.add('dtstart', source_event['StartDate'])
-        event.add('dtend', source_event['EndDate'] + timedelta(days=1))
-        event.add('location', source_event['Location'])
-        event.add('description', source_event['Comment'])
-        event.add('url', source_event['URL'])
+        event.add('dtstart', evt['StartDate'])
+        event.add('dtend', evt['EndDate'] + timedelta(days=1))
+        event.add('location', evt['Location'])
+        event.add('description', evt['Comment'])
+        event.add('url', evt['URL'])
         cal.add_component(event)
 
     with open(f"ical/{file}.ics", 'wb') as f:
@@ -113,24 +122,24 @@ for file in files:
 
 
 # Generate iCalendar files per single upcoming event
-for source_event in upcoming_events:
+for evt in upcoming_events:
     cal = Calendar()
     cal.add('prodid', '-//Hack er op uit//hackeropuit.nl//')
     cal.add('version', '2.0')
 
     event = Event()
     event.add('dtstamp', now)
-    event.add('uid', f"/{source_event['Name']}/{source_event['StartDate']}")
-    event.add('summary', source_event['Name'])
+    event.add('uid', f"/{evt['Name']}/{evt['StartDate']}")
+    event.add('summary', evt['Name'])
     event.add('transp', 'TRANSPARENT')
-    event.add('dtstart', source_event['StartDate'])
-    event.add('dtend', source_event['EndDate'] + timedelta(days=1))
-    event.add('location', source_event['Location'])
-    event.add('description', source_event['Comment'])
-    event.add('url', source_event['URL'])
+    event.add('dtstart', evt['StartDate'])
+    event.add('dtend', evt['EndDate'] + timedelta(days=1))
+    event.add('location', evt['Location'])
+    event.add('description', evt['Comment'])
+    event.add('url', evt['URL'])
     cal.add_component(event)
 
-    with open(source_event['iCal'], 'wb') as f:
+    with open(evt['iCal'], 'wb') as f:
         f.write(cal.to_ical())
 
 
@@ -141,19 +150,21 @@ for source_event in upcoming_events:
 youngest_event_file = now
 
 try:
-  # Get all files (not directories) in the directory with full paths
-  directory = EVENTDIR
-  files = [os.path.join(directory, f) for f in os.listdir(directory) 
-    if os.path.isfile(os.path.join(directory, f))]
-    
-  if files:
-    # Find the file with the latest (youngest) modification time
-    youngest_file = max(files, key=os.path.getmtime)
-    timestamp = os.path.getmtime(youngest_file)
-    youngest_event_file = datetime.fromtimestamp(timestamp)
+    # Get all files (not directories) in the directory with full paths
+    directory = EVENTDIR
+    files = [os.path.join(directory, f)
+             for f in os.listdir(directory)
+             if os.path.isfile(os.path.join(directory, f))
+             ]
+
+    if files:
+        # Find the file with the latest (youngest) modification time
+        youngest_file = max(files, key=os.path.getmtime)
+        timestamp = os.path.getmtime(youngest_file)
+        youngest_event_file = datetime.fromtimestamp(timestamp)
 
 except Exception as ex:
-  print(f"Error retrieving youngest timestamp : {ex}")
+    print(f"Error retrieving youngest timestamp : {ex}")
 
 
 # Determine authors
@@ -161,53 +172,81 @@ except Exception as ex:
 # 2. update with whomever is mentioned in codeowners file
 authors = ""
 try:
-  # Read the file
-  codeowners_list = []
-  with open('.github/CODEOWNERS', 'r', encoding='utf-8') as file:
-    codeowners_file = file.read()
-    codeowners_list = re.findall(r'@(\w+)', codeowners_file)
+    # Read the file
+    codeowners_list = []
+    with open('.github/CODEOWNERS', 'r', encoding='utf-8') as file:
+        codeowners_file = file.read()
+        codeowners_list = re.findall(r'@(\w+)', codeowners_file)
 
-  author_list = AUTHORS.split(',')
-  author_list.extend(codeowners_list)
+    author_list = AUTHORS.split(',')
+    author_list.extend(codeowners_list)
 
-  author_list = [author.strip().lower() for author in author_list]
+    author_list = [author.strip().lower() for author in author_list]
 
-  authors = ','.join(sorted(set(author_list)))
+    authors = ','.join(sorted(set(author_list)))
 
 except Exception as ex:
-  print(f"Error retrieving authors : {ex}")
-
+    print(f"Error retrieving authors : {ex}")
 
 
 # Store results in info dictionary
 keys = {
-    "{{NOW}}"                : now.isoformat(),
-    "{{GENERATOR_VERSION}}"  : VERSION,
-    "{{GENERATOR_REVISION}}" : datetime.fromtimestamp(os.path.getmtime(__file__)).isoformat(),
-    "{{LASTREFRESH}}"        : now.strftime("%Y-%m-%d %H:%M"),
-    "{{LASTEDIT}}"           : youngest_event_file.strftime("%Y-%m-%d %H:%M"),
-    "{{AUTHORS}}"            : authors
+    "{{NOW}}": now.isoformat(),
+    "{{GENERATOR_VERSION}}": VERSION,
+    "{{GENERATOR_REVISION}}": datetime.fromtimestamp(
+                                                    os.path.getmtime(__file__)
+                                                    )
+                                      .isoformat(),
+    "{{LASTREFRESH}}": now.strftime("%Y-%m-%d %H:%M"),
+    "{{LASTEDIT}}": youngest_event_file.strftime("%Y-%m-%d %H:%M"),
+    "{{AUTHORS}}": authors
 }
 
 
 # Define table structure
 tablefmt = {
-    "📅"        : {"hidden":"n", "export":"n", "type":"url", "field":"iCal"},
-    "Name"      : {"hidden":"n", "export":"y", "type":"txt", "field":"Name"},
-    "Location"  : {"hidden":"n", "export":"y", "type":"txt", "field":"Location"},
-    "Date"      : {"hidden":"n", "export":"n", "type":"txt", "field":"StartDate - EndDate"},
-    "StartDate" : {"hidden":"y", "export":"y", "type":"txt", "field":"StartDate"},
-    "EndDate"   : {"hidden":"y", "export":"y", "type":"txt", "field":"EndDate"},
-    "Comment"   : {"hidden":"n", "export":"y", "type":"txt", "field":"Comment"},
-    "Website"   : {"hidden":"n", "export":"y", "type":"url", "field":"URL"}
+    "📅": {"hidden": "n",
+          "export": "n",
+          "type": "url",
+          "field": "iCal"},
+    "Name": {"hidden": "n",
+             "export": "y",
+             "type": "txt",
+             "field": "Name"},
+    "Location": {"hidden": "n",
+                 "export": "y",
+                 "type": "txt",
+                 "field": "Location"},
+    "Date": {"hidden": "n",
+             "export": "n",
+             "type": "txt",
+             "field": "StartDate - EndDate"},
+    "StartDate": {"hidden": "y",
+                  "export": "y",
+                  "type": "txt",
+                  "field": "StartDate"},
+    "EndDate": {"hidden": "y",
+                "export": "y",
+                "type": "txt",
+                "field": "EndDate"},
+    "Comment": {"hidden": "n",
+                "export": "y",
+                "type": "txt",
+                "field": "Comment"},
+    "Website": {"hidden": "n",
+                "export": "y",
+                "type": "url",
+                "field": "URL"}
 }
 
-field_separators = [' ','-']
+field_separators = [' ', '-']
+
 
 def split_by_separators(text, separators):
     escaped = [re.escape(sep) for sep in separators]
     pattern = f"({'|'.join(escaped)})"
     return [part for part in re.split(pattern, text) if part != '']
+
 
 def get_field_value(event, column_name):
     formatted_value = ""
@@ -224,7 +263,7 @@ def get_field_value(event, column_name):
                 value = str(event[field])
                 retrieved.append(value)
 
-            except:
+            except Exception:
                 value = str(field)
 
             values.append(value)
@@ -258,8 +297,7 @@ def get_column_class(column_name):
     return class_txt
 
 
-
-#try:
+# try:
 with open("index.tpl", "r", encoding="utf-8") as htmlfile:
     content = htmlfile.read()
 
@@ -289,8 +327,6 @@ with open("index.tpl", "r", encoding="utf-8") as htmlfile:
             thead.append(tr)
 
             for idx, column_name in enumerate(tablefmt):
-                #fmt = tablefmt[key]
-
                 th = soup.new_tag("th")
                 th['onclick'] = f'sortTable({idx})'
 
@@ -317,27 +353,21 @@ with open("index.tpl", "r", encoding="utf-8") as htmlfile:
                 tbody.append(tr)
 
                 for column_name in tablefmt:
-                    #fmt = tablefmt[column_name]
-
                     td = soup.new_tag("td")
 
                     class_text = get_column_class(column_name)
                     if class_text != "":
-                       td['class'] = class_text
-
-                    #td.string = get_field_value(event, column_name)
-                    #tr.append(td)
+                        td['class'] = class_text
 
                     formatted_value = get_field_value(event, column_name)
-                    fragment_soup = BeautifulSoup(formatted_value, "html.parser")
+                    fragment_soup = BeautifulSoup(formatted_value,
+                                                  "html.parser")
                     td.append(fragment_soup)
                     tr.append(td)
-
-
 
     pretty_safe_html = soup.prettify(formatter="html")
     with open(OUTPUTFILE, "w", encoding="utf-8") as htmlfile:
         htmlfile.write(str(pretty_safe_html))
 
-#except Exception as ex:
+# except Exception as ex:
 #    print(f'Error creating index.html: {ex}')

--- a/update-website.py
+++ b/update-website.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+
+import os
+import glob
+import ruamel.yaml as ruamel_yaml
+from pathlib import Path
+from operator import itemgetter
+from datetime import datetime, date, timedelta, timezone
+from icalendar import Calendar, Event
+from bs4 import BeautifulSoup
+import re
+
+# Configuration
+OUTPUTFILE = 'new_index.html'
+EVENTDIR   = 'events'
+ICALDIR    = 'ical'
+VERSION    = '1.0'
+AUTHORS    = 'sigio,ubuntu-demon,kominoshja,tjclement,dekkers,JolienF,dutchmartin,amarsman,brainsmoke,eloydegen,juerd,stappersg,xesxen,mischapeters,polyfloyd,zeno4ever,toshywoshy,boekenwuurm,dvanzuilekom,elborro'
+
+# Store current time to use the same timestamp in all generated files
+now = datetime.now(timezone.utc)
+
+
+# Read yaml event files
+all_events = []
+yaml = ruamel_yaml.YAML(typ='safe', pure=True)
+for filename in glob.glob("events/*.yaml"):
+    try:
+        with open(filename, "r", encoding="utf-8") as eventfile:
+            eventdata = yaml.load(eventfile)
+
+            events=[]
+            if isinstance(eventdata, list):
+                events.extend(eventdata)
+            elif isinstance(eventdata, dict):
+                events.append(eventdata)
+
+            for idx, event in enumerate(events):
+                filestem = Path(filename).stem
+                event['file'] = filestem
+                event['iCal'] = f"ical/{filestem}{idx}.ics"
+
+            all_events.extend(events)
+    except ruamel_yaml.YAMLError as ex:
+        print(f"Error parsing {filename}: {ex}")
+    except Exception as ex:
+        print(f"Error handling {filename}: {ex}")
+
+
+# Sort events in chronological order
+all_events = sorted(all_events, key=itemgetter('StartDate'))
+
+
+# Filter already passed events
+today = date.today()
+upcoming_events = [event for event in all_events if event['StartDate'] <= event['EndDate'] and today <= event['EndDate']]
+
+
+# Clean up iCalender folder
+for filename in glob.glob("ical/*.ics"):
+    try:
+        os.remove(filename)
+    except Exception as ex:
+        print(f"Failed to delete {filename}. {ex}")
+
+
+# Generate iCalendar file with all events
+cal = Calendar()
+cal.add('prodid', '-//Hack er op uit//hackeropuit.nl//')
+cal.add('version', '2.0')
+
+for source_event in all_events:
+    event = Event()
+    event.add('dtstamp', now)
+    event.add('uid', f"/{source_event['Name']}/{source_event['StartDate']}")
+    event.add('summary', source_event['Name'])
+    event.add('transp', 'TRANSPARENT')
+    event.add('dtstart', source_event['StartDate'])
+    event.add('dtend', source_event['EndDate'] + timedelta(days=1))
+    event.add('location', source_event['Location'])
+    event.add('description', source_event['Comment'])
+    event.add('url', source_event['URL'])
+    cal.add_component(event)
+
+with open('ical/all_events.ics', 'wb') as f:
+    f.write(cal.to_ical())
+
+
+# Generate iCalendar files per event source
+files = list({event['file'] for event in all_events})
+for file in files:
+    source_events = [event for event in all_events if event['file'] == file]
+
+    cal = Calendar()
+    cal.add('prodid', '-//Hack er op uit//hackeropuit.nl//')
+    cal.add('version', '2.0')
+
+    for source_event in source_events:
+        event = Event()
+        event.add('dtstamp', now)
+        event.add('uid', f"/{source_event['Name']}/{source_event['StartDate']}")
+        event.add('summary', source_event['Name'])
+        event.add('transp', 'TRANSPARENT')
+        event.add('dtstart', source_event['StartDate'])
+        event.add('dtend', source_event['EndDate'] + timedelta(days=1))
+        event.add('location', source_event['Location'])
+        event.add('description', source_event['Comment'])
+        event.add('url', source_event['URL'])
+        cal.add_component(event)
+
+    with open(f"ical/{file}.ics", 'wb') as f:
+        f.write(cal.to_ical())
+
+
+# Generate iCalendar files per single upcoming event
+for source_event in upcoming_events:
+    cal = Calendar()
+    cal.add('prodid', '-//Hack er op uit//hackeropuit.nl//')
+    cal.add('version', '2.0')
+
+    event = Event()
+    event.add('dtstamp', now)
+    event.add('uid', f"/{source_event['Name']}/{source_event['StartDate']}")
+    event.add('summary', source_event['Name'])
+    event.add('transp', 'TRANSPARENT')
+    event.add('dtstart', source_event['StartDate'])
+    event.add('dtend', source_event['EndDate'] + timedelta(days=1))
+    event.add('location', source_event['Location'])
+    event.add('description', source_event['Comment'])
+    event.add('url', source_event['URL'])
+    cal.add_component(event)
+
+    with open(source_event['iCal'], 'wb') as f:
+        f.write(cal.to_ical())
+
+
+# Collect key information
+
+
+# Retrieve timestamp of youngest event file
+youngest_event_file = now
+
+try:
+  # Get all files (not directories) in the directory with full paths
+  directory = EVENTDIR
+  files = [os.path.join(directory, f) for f in os.listdir(directory) 
+    if os.path.isfile(os.path.join(directory, f))]
+    
+  if files:
+    # Find the file with the latest (youngest) modification time
+    youngest_file = max(files, key=os.path.getmtime)
+    timestamp = os.path.getmtime(youngest_file)
+    youngest_event_file = datetime.fromtimestamp(timestamp)
+
+except Exception as ex:
+  print(f"Error retrieving youngest timestamp : {ex}")
+
+
+# Determine authors
+# 1. Use manual maintained author list and
+# 2. update with whomever is mentioned in codeowners file
+authors = ""
+try:
+  # Read the file
+  codeowners_list = []
+  with open('.github/CODEOWNERS', 'r', encoding='utf-8') as file:
+    codeowners_file = file.read()
+    codeowners_list = re.findall(r'@(\w+)', codeowners_file)
+
+  author_list = AUTHORS.split(',')
+  author_list.extend(codeowners_list)
+
+  author_list = [author.strip().lower() for author in author_list]
+
+  authors = ','.join(sorted(set(author_list)))
+
+except Exception as ex:
+  print(f"Error retrieving authors : {ex}")
+
+
+
+# Store results in info dictionary
+keys = {
+    "{{NOW}}"                : now.isoformat(),
+    "{{GENERATOR_VERSION}}"  : VERSION,
+    "{{GENERATOR_REVISION}}" : datetime.fromtimestamp(os.path.getmtime(__file__)).isoformat(),
+    "{{LASTREFRESH}}"        : now.strftime("%Y-%m-%d %H:%M"),
+    "{{LASTEDIT}}"           : youngest_event_file.strftime("%Y-%m-%d %H:%M"),
+    "{{AUTHORS}}"            : authors
+}
+
+
+# Define table structure
+tablefmt = {
+    "📅"        : {"hidden":"n", "export":"n", "type":"url", "field":"iCal"},
+    "Name"      : {"hidden":"n", "export":"y", "type":"txt", "field":"Name"},
+    "Location"  : {"hidden":"n", "export":"y", "type":"txt", "field":"Location"},
+    "Date"      : {"hidden":"n", "export":"n", "type":"txt", "field":"StartDate - EndDate"},
+    "StartDate" : {"hidden":"y", "export":"y", "type":"txt", "field":"StartDate"},
+    "EndDate"   : {"hidden":"y", "export":"y", "type":"txt", "field":"EndDate"},
+    "Comment"   : {"hidden":"n", "export":"y", "type":"txt", "field":"Comment"},
+    "Website"   : {"hidden":"n", "export":"y", "type":"url", "field":"URL"}
+}
+
+field_separators = [' ','-']
+
+def split_by_separators(text, separators):
+    escaped = [re.escape(sep) for sep in separators]
+    pattern = f"({'|'.join(escaped)})"
+    return [part for part in re.split(pattern, text) if part != '']
+
+def get_field_value(event, column_name):
+    formatted_value = ""
+
+    try:
+        fmt = tablefmt[column_name]
+
+        retrieved = []
+        values = []
+        fields = split_by_separators(fmt['field'], field_separators)
+
+        for field in fields:
+            try:
+                value = str(event[field])
+                retrieved.append(value)
+
+            except:
+                value = str(field)
+
+            values.append(value)
+
+        if len(retrieved) > len(set(retrieved)):
+            formatted_value = values[0]
+        else:
+            formatted_value = "".join(values)
+
+        if fmt['type'] == "url":
+            formatted_value = f"<a href='{formatted_value}'>{column_name}</a>"
+
+    except Exception as ex:
+        formatted_value = f"get_field_value: {ex}"
+
+    return formatted_value
+
+
+def get_column_class(column_name):
+    class_txt = ""
+
+    fmt = tablefmt[column_name]
+    if fmt['hidden'] == 'y':
+        class_txt += "hidden-col"
+
+    if fmt['export'] == 'n':
+        if class_txt != "":
+            class_txt += " "
+        class_txt += "noexport"
+
+    return class_txt
+
+
+
+#try:
+with open("index.tpl", "r", encoding="utf-8") as htmlfile:
+    content = htmlfile.read()
+
+    # Find and replace all keys
+    for key in keys:
+        content = content.replace(key, keys[key])
+
+    # Parse html
+    soup = BeautifulSoup(content, "html.parser")
+    if not soup:
+        print("ERROR Template index.tpl not recognized as HTML")
+    else:
+        eventtable = soup.find(id="events")
+
+        if not eventtable:
+            print('ERROR Eventtable ID not found')
+        else:
+            table = soup.new_tag("table")
+            table['id'] = 'eventtable'
+            eventtable.append(table)
+
+            # Create header
+            thead = soup.new_tag("thead")
+            table.append(thead)
+
+            tr = soup.new_tag("tr")
+            thead.append(tr)
+
+            for idx, column_name in enumerate(tablefmt):
+                #fmt = tablefmt[key]
+
+                th = soup.new_tag("th")
+                th['onclick'] = f'sortTable({idx})'
+
+                class_text = get_column_class(column_name)
+                if class_text != "":
+                    th['class'] = class_text
+
+                th.string = column_name
+                tr.append(th)
+
+            # Create content
+            tbody = soup.new_tag("tbody")
+            table.append(tbody)
+
+            rowpow = ''
+            for idx, event in enumerate(upcoming_events):
+                if idx % 2 == 0:
+                    rowpos = 'even'
+                else:
+                    rowpos = 'odd'
+
+                tr = soup.new_tag("tr")
+                tr['class'] = rowpos
+                tbody.append(tr)
+
+                for column_name in tablefmt:
+                    #fmt = tablefmt[column_name]
+
+                    td = soup.new_tag("td")
+
+                    class_text = get_column_class(column_name)
+                    if class_text != "":
+                       td['class'] = class_text
+
+                    #td.string = get_field_value(event, column_name)
+                    #tr.append(td)
+
+                    formatted_value = get_field_value(event, column_name)
+                    fragment_soup = BeautifulSoup(formatted_value, "html.parser")
+                    td.append(fragment_soup)
+                    tr.append(td)
+
+
+
+    pretty_safe_html = soup.prettify(formatter="html")
+    with open(OUTPUTFILE, "w", encoding="utf-8") as htmlfile:
+        htmlfile.write(str(pretty_safe_html))
+
+#except Exception as ex:
+#    print(f'Error creating index.html: {ex}')


### PR DESCRIPTION
Can be tested without interrupting normal function of the website.

Goals
1. Generate and deliver all content at once.
2. Simplify html and css without major change in looks
3. Introduce ical download per event
4. Allow visitor to search and filter for events
5. Allow visitor to sort the table content
6. Allow visitor to export current view to comma separated and/or icalendar format.

Updates
- Site generation script reads event yaml files as source; json has been phased out.
- ical subdirectory directory holds pre-generated ics files per event, per source file (not used yet), and all_events.ics containing all events including events that have already taken place. It receives a complete refresh every time the site update script runs.
- The generated html file contains all content of upcoming events.
- The stylesheet moved into a separate hackeropuit.css file
- JavaScript is only used to add behaviour to the site, NOT to retrieve content.
- JavaScript moved into a separate hackeropuit.js file
- JavaScript column sort: Select the column name to sort, twice to switch ascending/descending order.
- JavaScript filter: filter and highlight while you type.
- JavaScript csv export: Exports the current shown (filtered) events only, as one csv file.
- JavaScript ical export: Exports the current shown (filtered) events only, as one icalendar file.
- Added separate indicators of last time the generator refreshed the site code and most recent update to the event yaml files.
- Added index.tpl as a standard template with tokens that get replaced during site generation and anchor to indicate where to insert the new generated table.
- Code realigned to satisfy Flake8

Known issues
- After using the filter, the column sort does not always correctly show the alternating colours per events.