### PR TITLE
Add EMFCamp 2026 and Fri3dCamp 2026, fix eth0 comment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@ events/bitlair.yaml @polyfloyd
 events/bornhack.yaml @xesxen
 events/bsdnl.yaml @mischapeters
 events/cfgmgmtcamp.yaml @toshywoshy
-events/eth0.yaml @eloydegen
+events/eth0.yaml @eloydegen @dekkers
 events/eurobsdcon.yaml @mischapeters
 events/hack42.yaml @dvanzuijlekom
 events/hackalot.yaml @xesxen @boekenwuurm

--- a/events/emfcamp.yaml
+++ b/events/emfcamp.yaml
@@ -6,5 +6,11 @@
   EndDate: 2024-06-02
   Comment: HackerCamp
   URL: https://www.emfcamp.org/
+- Name: EMFCamp 2026
+  Location: Eastnor, UK
+  StartDate: 2024-07-16
+  EndDate: 2024-07-19
+  Comment: HackerCamp
+  URL: https://www.emfcamp.org/
 
 ...

--- a/events/eth0.yaml
+++ b/events/eth0.yaml
@@ -4,13 +4,13 @@
   Location: Lievelde, NL
   StartDate: 2022-10-28
   EndDate: 2022-10-30
-  Comment: HackerCamp
+  Comment: HackerConf
   URL: https://wiki.eth0.nl/index.php/Eth0:2022_Autumn
 - Name: eth0:2025 Autumn
   Location: Someren, NL
   StartDate: 2025-10-31
   EndDate: 2025-11-02
-  Comment: HackerCamp
+  Comment: HackerConf
   URL: https://wiki.eth0.nl/index.php/Eth0:2025_Autumn
 
 ...

--- a/events/fri3dcamp.yaml
+++ b/events/fri3dcamp.yaml
@@ -6,5 +6,11 @@
   EndDate: 2024-08-18
   Comment: MakerCamp
   URL: https://fri3d.be/
+- Name: Fri3dCamp 2026
+  Location: T.B.D.
+  StartDate: 2026-08-14
+  EndDate: 2026-08-16
+  Comment: MakerCamp
+  URL: https://fri3d.be/
 
 ...


### PR DESCRIPTION
- Added EMFCamp 2026
- Added Fri3dCamp 2026
- Eth0 autumn has "HackerCamp" as comment, but is indoors, so I guess this should be "HackerConf"
- Added myself to the eth0 codeowners.